### PR TITLE
Better font loading

### DIFF
--- a/css/directory.css
+++ b/css/directory.css
@@ -270,13 +270,6 @@ th {
 .grid-cell__verticallyAligned {
   vertical-align: middle;
 }
-.wf-loading,
-.wf-inactive {
-  opacity: 0;
-}
-.wf-active {
-  opacity: 1;
-}
 .loader,
 .loader:before,
 .loader:after {
@@ -674,8 +667,11 @@ body {
   color: #f5f5f5;
 }
 .main-wrap {
-  font-family: 'Open Sans', Helvetica, Arial, sans-serif;
+  font-family: Helvetica, Arial, sans-serif;
   font-weight: 300;
+}
+.wf-active .main-wrap {
+  font-family: 'Open Sans', Helvetica, Arial, sans-serif;
 }
 .header {
   margin-bottom: 5rem;
@@ -718,7 +714,7 @@ body {
 }
 .header__title {
   display: block;
-  font-family: 'Oswald', sans-serif;
+  font-family: sans-serif;
   font-size: 3.9375rem;
   font-weight: normal;
   letter-spacing: 0.21875rem;
@@ -733,6 +729,13 @@ body {
     padding-left: 1rem;
     padding-right: 1rem;
   }
+}
+.wf-loading .header__title,
+.wf-inactive .header__title {
+  font-size: 3rem;
+}
+.wf-active .header__title {
+  font-family: 'Oswald', sans-serif;
 }
 .header__sub-title {
   color: #bcc0c3;

--- a/js/webfonts.js
+++ b/js/webfonts.js
@@ -2,7 +2,7 @@
 (function(document) {
   WebFontConfig = {
     google: {
-      families: ['Oswald', 'Open Sans:300,700'],
+      families: ['Oswald', 'Open Sans:300,700']
     }
   };
   var wf = document.createElement('script'), s = document.scripts[0];

--- a/scripts/directory.js
+++ b/scripts/directory.js
@@ -233,7 +233,7 @@
 (function(document) {
   WebFontConfig = {
     google: {
-      families: ['Oswald', 'Open Sans:300,700'],
+      families: ['Oswald', 'Open Sans:300,700']
     }
   };
   var wf = document.createElement('script'), s = document.scripts[0];

--- a/styles/_font.styl
+++ b/styles/_font.styl
@@ -1,6 +1,0 @@
-.wf-loading, .wf-inactive {
-    opacity: 0;
-}
-.wf-active {
-    opacity: 1;
-}

--- a/styles/directory.styl
+++ b/styles/directory.styl
@@ -85,7 +85,7 @@ body {
 .wf-loading,
 .wf-inactive {
     .header__title {
-        // chris.roberson: Make this slightly smaller to put it in two lines instead of one
+        // chris.roberson: Make this slightly smaller to put the header on two lines instead of three
         font-size: 3rem
     }
 }

--- a/styles/directory.styl
+++ b/styles/directory.styl
@@ -3,7 +3,6 @@
 @import "_colors.styl";
 @import "_mixins.styl";
 @import "_grid.styl";
-@import "_font.styl";
 @import "_loading.styl";
 @import "cta.styl";
 @import "projects.styl";
@@ -18,8 +17,13 @@ body {
 }
 
 .main-wrap {
-    font-family: 'Open Sans', Helvetica, Arial, sans-serif;
+    font-family: Helvetica, Arial, sans-serif;
     font-weight: 300;
+}
+.wf-active {
+    .main-wrap {
+        font-family: 'Open Sans', Helvetica, Arial, sans-serif;
+    }
 }
 
 .header {
@@ -65,7 +69,7 @@ body {
 
 .header__title {
     display: block;
-    font-family: 'Oswald', sans-serif;
+    font-family: sans-serif;
     font-size: 3.9375rem;
     font-weight: normal;
     letter-spacing: 0.21875rem;
@@ -76,6 +80,18 @@ body {
         text-align: center
         font-size: 2.625rem;
         mobile-padding()
+    }
+}
+.wf-loading,
+.wf-inactive {
+    .header__title {
+        // chris.roberson: Make this slightly smaller to put it in two lines instead of one
+        font-size: 3rem
+    }
+}
+.wf-active {
+    .header__title {
+        font-family: 'Oswald', sans-serif;
     }
 }
 


### PR DESCRIPTION
Per [Zach Leatherman](http://www.zachleat.com/web/foft/), we can do a better job of loading our fonts asynchronously. 

This fix involves not actually setting the async font on the CSS blocks until *after* the font actually loads. We're using [WebFontLoader](https://github.com/typekit/webfontloader) which will add class names to the `<html>` tag to indicate the status of the async font loading - with this, we'll only set the async fonts when the `wf-active` class is present.

## Previous (bad)
![bad-font](https://cloud.githubusercontent.com/assets/56682/8575331/782a32c4-2569-11e5-87b3-123aa7b62eb6.gif)

## New (good)
![good-font](https://cloud.githubusercontent.com/assets/56682/8575344/82e03740-2569-11e5-81c2-a2e276958fa3.gif)


